### PR TITLE
Reverse relations input in mutations update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ wheels/
 *.egg
 MANIFEST
 
+# ide files
+.idea/*
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ query {
 
 Here is an example describing how to use those:
 
-```
+```py
 import graphene
 from graphene import relay
 
@@ -293,11 +293,13 @@ mutation {
 Any validation errors will be presented in the `errors` return value.
 
 To turn off auto related relations addition to the mutation input - set global `MUTATIONS_INCLUDE_REVERSE_RELATIONS` parameter to `False` in your `settings.py`:
-```py
+```
 GRAPHENE_DJANGO_PLUS = {
     'MUTATIONS_INCLUDE_REVERSE_RELATIONS': False
 }
 ```
+
+Note: in case reverse relation does not have `related_name` attribute set - mutation input will be generated as Django itself is generating by appending `_set` to the lower cased model name - `modelname_set`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ query {
 
 Here is an example describing how to use those:
 
-```py
+```
 import graphene
 from graphene import relay
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,13 @@ mutation {
 
 Any validation errors will be presented in the `errors` return value.
 
+To turn off auto related relations addition to the mutation input - set global `MUTATIONS_INCLUDE_REVERSE_RELATIONS` parameter to `False` in your `settings.py`:
+```py
+GRAPHENE_DJANGO_PLUS = {
+    'MUTATIONS_INCLUDE_REVERSE_RELATIONS': False
+}
+```
+
 ## License
 
 This project is licensed under MIT licence (see `LICENSE` for more info)

--- a/graphene_django_plus/mutations.py
+++ b/graphene_django_plus/mutations.py
@@ -36,6 +36,7 @@ from .perms import (
     check_perms,
     check_authenticated,
 )
+from .settings import graphene_django_plus_settings
 from .utils import (
     get_node,
     get_nodes,
@@ -94,7 +95,7 @@ def _get_fields(model, only_fields, exclude_fields, required_fields):
     # can be set to null, otherwise updates won't work.
     fields.extend(
         [
-            (field.related_name, field)
+            (field.related_name or field.name + "_set", field)
             for field in sorted(
                 list(model._meta.related_objects),
                 key=lambda field: field.name,
@@ -102,6 +103,7 @@ def _get_fields(model, only_fields, exclude_fields, required_fields):
             if not isinstance(field, ManyToOneRel) or field.remote_field.null
         ],
     )
+    print(fields)
 
     ret = collections.OrderedDict()
     for name, field in fields:
@@ -133,6 +135,11 @@ def _get_fields(model, only_fields, exclude_fields, required_fields):
                 description=field.help_text,
             )
         elif isinstance(field, (ManyToOneRel, ManyToManyRel)):
+            reverse_relations_include = graphene_django_plus_settings.MUTATIONS_INCLUDE_REVERSE_RELATIONS
+            # Explicitly checking whether it was globally configured to not include reverse relations
+            if isinstance(field, ManyToOneRel) and not reverse_relations_include and not only_fields:
+                continue
+
             ret[name] = graphene.List(
                 graphene.ID,
                 description='Set list of {0}'.format(
@@ -573,7 +580,7 @@ class ModelMutation(BaseModelMutation):
         cls.clean_instance(instance, cleaned_input)
         cls.save(info, instance, cleaned_input)
 
-        # save m2m data
+        # save m2m and related object's data
         for f in itertools.chain(
             instance._meta.many_to_many,
             instance._meta.related_objects,
@@ -581,9 +588,9 @@ class ModelMutation(BaseModelMutation):
         ):
             if isinstance(f, (ManyToOneRel, ManyToManyRel)):
                 # Handle reverse side relationships.
-                d = cleaned_input.get(f.related_name, None)
+                d = cleaned_input.get(f.related_name or f.name + "_set", None)
                 if d is not None:
-                    target_field = getattr(instance, f.related_name)
+                    target_field = getattr(instance, f.related_name or f.name + "_set")
                     target_field.set(d)
             elif hasattr(f, 'save_form_data'):
                 d = cleaned_input.get(f.name, None)

--- a/graphene_django_plus/mutations.py
+++ b/graphene_django_plus/mutations.py
@@ -103,7 +103,6 @@ def _get_fields(model, only_fields, exclude_fields, required_fields):
             if not isinstance(field, ManyToOneRel) or field.remote_field.null
         ],
     )
-    print(fields)
 
     ret = collections.OrderedDict()
     for name, field in fields:
@@ -135,9 +134,9 @@ def _get_fields(model, only_fields, exclude_fields, required_fields):
                 description=field.help_text,
             )
         elif isinstance(field, (ManyToOneRel, ManyToManyRel)):
-            reverse_relations_include = graphene_django_plus_settings.MUTATIONS_INCLUDE_REVERSE_RELATIONS
-            # Explicitly checking whether it was globally configured to not include reverse relations
-            if isinstance(field, ManyToOneRel) and not reverse_relations_include and not only_fields:
+            reverse_rel_include = graphene_django_plus_settings.MUTATIONS_INCLUDE_REVERSE_RELATIONS
+            # Checking whether it was globally configured to not include reverse relations
+            if isinstance(field, ManyToOneRel) and not reverse_rel_include and not only_fields:
                 continue
 
             ret[name] = graphene.List(

--- a/graphene_django_plus/settings.py
+++ b/graphene_django_plus/settings.py
@@ -1,0 +1,124 @@
+"""
+Settings for graphene-django-plus are all namespaced in the GRAPHENE_DJANGO_PLUS setting.
+For example your project's `settings.py` file might look like this:
+GRAPHENE_DJANGO_PLUS = {
+    'MUTATIONS_INCLUDE_REVERSE_RELATIONS': False
+}
+This module provides the `graphene_django_plus_settings` object, that is used to access
+graphene-django-plus settings, checking for user settings first, then falling
+back to the defaults.
+"""
+from __future__ import unicode_literals
+
+import six
+from django.conf import settings
+from django.test.signals import setting_changed
+
+import importlib
+
+
+# Copied shamelessly from Django REST Framework and graphene-django
+
+DEFAULTS = {
+    "MUTATIONS_INCLUDE_REVERSE_RELATIONS": True,
+}
+
+# List of settings that may be in string import notation.
+IMPORT_STRINGS = []
+
+
+def perform_import(val, setting_name):
+    """
+    If the given setting is a string import notation,
+    then perform the necessary import or imports.
+    """
+    if val is None:
+        return None
+    elif isinstance(val, six.string_types):
+        return import_from_string(val, setting_name)
+    elif isinstance(val, (list, tuple)):
+        return [import_from_string(item, setting_name) for item in val]
+    return val
+
+
+def import_from_string(val, setting_name):
+    """
+    Attempt to import a class from a string representation.
+    """
+    try:
+        # Nod to tastypie's use of importlib.
+        parts = val.split(".")
+        module_path, class_name = ".".join(parts[:-1]), parts[-1]
+        module = importlib.import_module(module_path)
+        return getattr(module, class_name)
+    except (ImportError, AttributeError) as e:
+        msg = "Could not import '%s' for graphene-django-plus setting '%s'. %s: %s." % (
+            val,
+            setting_name,
+            e.__class__.__name__,
+            e,
+        )
+        raise ImportError(msg)
+
+
+class GrapheneDjangoPlusSettings(object):
+    """
+    A settings object, that allows API settings to be accessed as properties.
+    For example:
+        from graphene_django_plus.settings import settings
+        print(settings.MUTATIONS_INCLUDE_REVERSE_RELATIONS)
+    Any setting with string import paths will be automatically resolved
+    and return the class, rather than the string literal.
+    """
+
+    def __init__(self, user_settings=None, defaults=None, import_strings=None):
+        if user_settings:
+            self._user_settings = user_settings
+        self.defaults = defaults or DEFAULTS
+        self.import_strings = import_strings or IMPORT_STRINGS
+        self._cached_attrs = set()
+
+    @property
+    def user_settings(self):
+        if not hasattr(self, "_user_settings"):
+            self._user_settings = getattr(settings, "GRAPHENE_DJANGO_PLUS", {})
+        return self._user_settings
+
+    def reload(self):
+        for attr in self._cached_attrs:
+            delattr(self, attr)
+        self._cached_attrs.clear()
+        if hasattr(self, '_user_settings'):
+            delattr(self, '_user_settings')
+
+    def __getattr__(self, attr):
+        if attr not in self.defaults:
+            raise AttributeError("Invalid graphene-django-plus setting: '%s'" % attr)
+
+        try:
+            # Check if present in user settings
+            val = self.user_settings[attr]
+        except KeyError:
+            # Fall back to defaults
+            val = self.defaults[attr]
+
+        # Coerce import strings into classes
+        if attr in self.import_strings:
+            val = perform_import(val, attr)
+
+        # Cache the result
+        self._cached_attrs.add(attr)
+        setattr(self, attr, val)
+        return val
+
+
+graphene_django_plus_settings = GrapheneDjangoPlusSettings(None, DEFAULTS, IMPORT_STRINGS)
+
+
+def reload_graphene_django_plus_settings(*args, **kwargs):
+    setting = kwargs["setting"]
+    if setting == "GRAPHENE_DJANGO_PLUS":
+        graphene_django_plus_settings.reload()
+
+
+setting_changed.connect(reload_graphene_django_plus_settings)

--- a/tests/models.py
+++ b/tests/models.py
@@ -67,6 +67,5 @@ class MilestoneComment(models.Model):
         Milestone,
         null=True,
         blank=True,
-        default=None,
         on_delete=models.SET_NULL,
     )

--- a/tests/models.py
+++ b/tests/models.py
@@ -56,3 +56,17 @@ class Issue(GuardedModel):
         default=None,
         on_delete=models.SET_NULL,
     )
+
+
+class MilestoneComment(models.Model):
+
+    text = models.CharField(
+        max_length=255,
+    )
+    milestone = models.ForeignKey(
+        Milestone,
+        null=True,
+        blank=True,
+        default=None,
+        on_delete=models.SET_NULL,
+    )

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -16,6 +16,7 @@ from .models import (
     Project,
     Milestone,
     Issue,
+    MilestoneComment,
 )
 
 # Types
@@ -43,6 +44,14 @@ class MilestoneType(ModelType):
 class ProjectType(ModelType):
     class Meta:
         model = Project
+        connection_class = CountableConnection
+        interfaces = [relay.Node]
+        filter_fields = {}
+
+
+class MilestoneCommentType(ModelType):
+    class Meta:
+        model = MilestoneComment
         connection_class = CountableConnection
         interfaces = [relay.Node]
         filter_fields = {}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,20 @@
+from django.test import TestCase, override_settings
+
+from graphene_django_plus.settings import graphene_django_plus_settings
+
+
+class TestSettings(TestCase):
+
+    def test_compatibility_with_override_settings(self):
+        self.assertTrue(
+            graphene_django_plus_settings.MUTATIONS_INCLUDE_REVERSE_RELATIONS
+        )
+
+        with override_settings(GRAPHENE_DJANGO_PLUS={'MUTATIONS_INCLUDE_REVERSE_RELATIONS': False}):
+            self.assertFalse(
+                graphene_django_plus_settings.MUTATIONS_INCLUDE_REVERSE_RELATIONS
+            )  # Setting should have been updated
+
+        self.assertTrue(
+            graphene_django_plus_settings.MUTATIONS_INCLUDE_REVERSE_RELATIONS
+        )  # Setting should have been restored


### PR DESCRIPTION
* Added global settings. 
* Fixed relation without related_name ObjectType creation (will be added as `modelname_set`)
* Added possibility to turn off auto related-name generation for mutations through global setting

This PR is for resolving issue https://github.com/0soft/graphene-django-plus/issues/13